### PR TITLE
Adds schema checks, sort of...

### DIFF
--- a/config.local.js
+++ b/config.local.js
@@ -84,6 +84,7 @@ module.exports = {
         login: 'frank'
     },
     options: {
-        origin: 'https://openag.io'
+        origin: 'https://openag.io',
+        oadaFormatsPackages: ['valleyix-formats']
     }
 };

--- a/package.json
+++ b/package.json
@@ -18,11 +18,13 @@
     "mocha": "^2.2.5",
     "mocha-steps": "0.0.1",
     "nconf": "^0.7.2",
+    "oada-formats": "^1.4.0",
     "pem-jwk": "^1.5.1",
     "phantom": "^0.7.2",
     "phantomjs": "^1.9.17",
     "superagent": "^1.4.0",
-    "superagent-bluebird-promise": "^2.1.0"
+    "superagent-bluebird-promise": "^2.1.0",
+    "valleyix-formats": "^1.2.0"
   },
   "devDependencies": {
     "jscs": "^2.1.1",


### PR DESCRIPTION
@awlayton: Here is a start at adding schema checking to `oada-compliance`. I'm thinking something more clean can be done but I didn't want too many huge changes without consulting you givin the early stages of `oada-compliance`.

There are validation errors when ran against the oada/oada-api-server until oada/oada-api-server#5 and oada/oada-api-server#6 are fixed. 

Validation errors do not cause the test to fail (just a debug() message). I didn't like that the entire sub-document test failed for just one mediatype failure. Maybe that is the right thing?
